### PR TITLE
add setting to disable reflective IP address detection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,11 @@ pub struct Config {
     /// Configuration options for "official" servers connected to a binder
     #[getset(get = "pub")]
     official: Option<OfficialConfig>,
+
+    /// Whether or not to get ip address from external service
+    #[getset(get_copy = "pub")]
+    #[serde(default)]
+    disable_reflective_ip_detection: bool,
 }
 
 fn sosistab_listen_default() -> String {

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -255,7 +255,7 @@ pub async fn main_loop(ctx: Arc<RootCtx>) -> anyhow::Result<()> {
         log::info!(
             "listening on {}@{}:{}",
             hex::encode(x25519_dalek::PublicKey::from(&ctx.sosistab_sk).to_bytes()),
-            if listen_addr.ip().is_unspecified() {
+            if listen_addr.ip().is_unspecified() && !ctx1.config.disable_reflective_ip_detection(){
                 IpAddr::from(*MY_PUBLIC_IP)
             } else {
                 listen_addr.ip()


### PR DESCRIPTION
Some users may need to disable reflective IP address detection in some self-hosted scenarios.

* The server is run inside a private network and the server has no access to the Internet.
* The server is run within a hostile network environment. The operator does not wish adversaries to gain knowledge that a geph4-exit is more likely to exist on a device. (HTTP communication with checkip.amazonaws.com, HTTP User-Agent: ureq/1.5.5)
* The operator does not wish Amazon to gain knowledge that a geph4-exit is more likely to exist on a network location.

This new setting keeps the default behaviour unchanged while allowing the user to define if geph4-exit should contact an external service to determine reflective IP address.

This is an individual contribution and does not represent affiliated organizations in any way.  
